### PR TITLE
cryptography 36.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,15 +20,16 @@ requirements:
     - vs2017_{{ target_platform }}    # [win]
   host:
     - python
+    - cffi >=1.12
+    - openssl
     - pip
     - setuptools >=40.6.0
     - setuptools-rust >=0.11.4
-    - openssl
-    - cffi >=1.12
+    - wheel
   run:
     - python
-    - openssl
     - cffi >=1.12
+    - openssl
     - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
 
 test:
@@ -48,15 +49,17 @@ test:
     - cryptography.x509
   requires:
     - cryptography-vectors {{ version }}
-    - hypothesis
+    - hypothesis >=1.11.4,!=3.79.2
     - iso8601
+    - pip
     - pretend
-    - pytest
+    - pytest >=6.2.0
     - pytest-subtests
     - pytz
   source_files:
     - tests
   commands:
+    - pip check
     # run_test.py will check that the correct openssl version is linked
     - pytest          # [not (arm64 or s390x or aarch64)]
     - pytest || true  # [arm64 or s390x or aarch64]
@@ -74,7 +77,7 @@ about:
     and PyPy 2.6+. Cryptography includes both high level recipes, and low level
     interfaces to common cryptographic algorithms such as symmetric ciphers,
     message digests and key derivation functions.
-  doc_url: http://cryptography.readthedocs.io/
+  doc_url: https://cryptography.io/
   doc_source_url: https://github.com/pyca/cryptography/blob/master/docs/index.rst
   dev_url: https://github.com/pyca/cryptography
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
   host:
     - python
     - cffi >=1.12
-    - openssl
     - pip
     - setuptools >=40.6.0
     - setuptools-rust >=0.11.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "35.0.0" %}
+{% set version = "36.0.0" %}
 
 package:
   name: cryptography
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: 9933f28f70d0517686bd7de36166dda42094eac49415459d9bdf5e7df3e0086d
+  sha256: 52f769ecb4ef39865719aedc67b4b7eae167bafa48dbc2a26dd36fa56460507f
 
 build:
   number: 0


### PR DESCRIPTION
Update cryptography to 36.0.0

Version change: bump version number from 35.0.0 to 36.0.0 (Major version bump)
Bug Tracker: new open issues https://github.com/pyca/cryptography/issues
Upstream Changelog: https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst
Upstream setup.cfg:  https://github.com/pyca/cryptography/blob/36.0.0/setup.cfg
Upstream setup.py:  https://github.com/pyca/cryptography/blob/36.0.0/setup.py
Upstream pyproject.toml: https://github.com/pyca/cryptography/blob/36.0.0/pyproject.toml

The package cryptography is mentioned inside the packages:
adal | airflow | authlib | celery | conda-content-trust | docker-py | flake8-import-order | flask-jwt-extended | google-auth-oauthlib | moto | oauthlib | paramiko | passlib | pycrypto | pyjwt | pymysql | pynacl | pyopenssl | requests-kerberos | requests_ntlm | secretstorage | service_identity | sqlalchemy-utils | sshpubkeys | trustme | twisted | urllib3 |

Actions:
1. Add missing package wheel in host
2. Rearrange dependencies alphabetically
3. Update test/requires dependencies
4. Add pip check
5. Fix doc_url

Result:
- all-succeeded
