### PR TITLE
cryptography 36.0.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-rust_compiler:
-  - rust
-rust_compiler_version:
-  - 1.46.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "36.0.0" %}
+{% set version = "36.0.1" %}
 
 package:
   name: cryptography
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: 52f769ecb4ef39865719aedc67b4b7eae167bafa48dbc2a26dd36fa56460507f
+  sha256: 53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
   host:
     - python
     - cffi >=1.12
-    - libffi  # [unix]
     - pip
     - setuptools >=40.6.0
     - setuptools-rust >=0.11.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,8 @@ build:
   number: 0
   skip: true  # [py<36 or win32]
   script: {{ PYTHON }} -m pip install . -vv
-  missing_dso_whitelist:  # [linux]
-    - $RPATH/ld64.so.1    # [linux]
+  #missing_dso_whitelist:  # [linux]
+  #  - $RPATH/ld64.so.1    # [linux]
 requirements:
   build:
     - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
   host:
     - python
     - cffi >=1.12
+    - libffi  # [unix]
     - pip
     - setuptools >=40.6.0
     - setuptools-rust >=0.11.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "cryptography" %}
 {% set version = "36.0.1" %}
 
 package:
-  name: cryptography
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography-{{ version }}.tar.gz
   sha256: 53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,8 @@ build:
   number: 0
   skip: true  # [py<36 or win32]
   script: {{ PYTHON }} -m pip install . -vv
-  #missing_dso_whitelist:  # [linux]
-  #  - $RPATH/ld64.so.1    # [linux]
+  missing_dso_whitelist:  # [linux and s390x]
+    - $RPATH/ld64.so.1    # [linux and s390x]
 requirements:
   build:
     - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
     - $RPATH/ld64.so.1    # [linux]
 requirements:
   build:
+    - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - vs2017_{{ target_platform }}    # [win]
   host:
@@ -64,7 +65,7 @@ test:
     - pytest || true  # [arm64 or s390x or aarch64]
 
 about:
-  home: https://github.com/pyca/cryptography
+  home: https://cryptography.io
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   license_file: LICENSE
@@ -76,7 +77,7 @@ about:
     and PyPy 2.6+. Cryptography includes both high level recipes, and low level
     interfaces to common cryptographic algorithms such as symmetric ciphers,
     message digests and key derivation functions.
-  doc_url: https://cryptography.io/
+  doc_url: https://cryptography.io/en/latest/
   doc_source_url: https://github.com/pyca/cryptography/blob/master/docs/index.rst
   dev_url: https://github.com/pyca/cryptography
 


### PR DESCRIPTION
Update cryptography to 36.0.1

Bug Tracker: new open issues https://github.com/pyca/cryptography/issues
Upstream Changelog: https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst
Upstream setup.cfg:  https://github.com/pyca/cryptography/blob/36.0.1/setup.cfg
Upstream setup.py:  https://github.com/pyca/cryptography/blob/36.0.1/setup.py
Upstream pyproject.toml: https://github.com/pyca/cryptography/blob/36.0.1/pyproject.toml

The package cryptography is mentioned inside the packages:
adal | airflow | authlib | celery | conda-content-trust | docker-py | flake8-import-order | flask-jwt-extended | google-auth-oauthlib | moto | oauthlib | paramiko | passlib | pycrypto | pyjwt | pymysql | pynacl | pyopenssl | requests-kerberos | requests_ntlm | secretstorage | service_identity | sqlalchemy-utils | sshpubkeys | trustme | twisted | urllib3 |

Actions:
1. Use jinja2 templates in source/url
2. Add compiler c in `build `and `libffi  # [unix]` in `host`, see https://cryptography.io/en/latest/installation/#building-cryptography-on-linux
3. Update home and doc urls