### PR TITLE
38.0.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  build: cryptography-vectors

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  build: cryptography
+  build: cryptography-vectors

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  build: cryptography

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "38.0.1" %}
+{% set version = "38.0.4" %}
 
 package:
   name: cryptography
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: 1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7
+  sha256: 175c1a818b87c9ac80bb7377f5520b7f31b3ef2a0004e2420319beadedb67290
 
 build:
   number: 0


### PR DESCRIPTION
# cryptography 38.0.4

upstream: https://github.com/pyca/cryptography/tree/38.0.4
license: https://github.com/pyca/cryptography/blob/38.0.4/LICENSE
changelog: https://cryptography.io/en/latest/changelog/#v38-0-4
jira: https://anaconda.atlassian.net/browse/PKG-901

## Related PRs
- https://github.com/AnacondaRecipes/cryptography-vectors-feedstock/pull/11

## Changes
- Update version and SHA

## Notes
- This needs to be updated after or at the same time as https://github.com/AnacondaRecipes/cryptography-vectors-feedstock/pull/11
- This release fixes two CVEs: CVE-2022-3602 and CVE-2022-3786.
- The `abs.yaml` file will be removed before merging.
- Artifacts can be seen here: https://anaconda.org/build/cryptography/files