### PR TITLE
Openssl3 build

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,8 @@
 channels:
   staging_openssl3: openssl3
+
+aggregate_branch: openssl3_builds
+
 build_parameters:
   - "--suppress-variables"
   #- "--skip-existing"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  staging_openssl3: openssl3
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,8 @@ requirements:
   run:
     - python
     - cffi >=1.12
-    - openssl >1.1.0,<3.1.0
-    - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
+    - openssl 3.*
+      - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - python
     - cffi >=1.12
-    - openssl >1.1.0, <3.1.0
+    - openssl >1.1.0,<3.1.0
     - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,9 @@ source:
   sha256: d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37 or win32]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 requirements:
@@ -28,7 +28,7 @@ requirements:
   run:
     - python
     - cffi >=1.12
-    - openssl
+    - openssl >1.1.0, <3.1.0
     - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<37 or win32]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:  # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - python
     - cffi >=1.12
     - openssl 3.*
-      - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
+    - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
 
 test:
   requires:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -20,8 +20,8 @@ linked_version = backend.openssl_version_text()
 # the version present in the conda environment
 env_version = subprocess.check_output('openssl version', shell=True).decode('utf8').strip()
 
-print('Version used by cryptography:\n{linked_version}'.format(linked_version=linked_version))
-print('Version in conda environment:\n{env_version}'.format(env_version=env_version))
+print(f'Version used by cryptography:\n{linked_version}')
+print(f'Version in conda environment:\n{env_version}')
 
 # avoid race condition between print and (possible) AssertionError
 time.sleep(1)
@@ -29,4 +29,5 @@ time.sleep(1)
 # linking problems have appeared on windows before (see issue #38),
 # and were only caught by lucky accident through the test suite.
 # This is intended to ensure it does not happen again.
-assert linked_version == env_version
+
+assert env_version.startswith(linked_version)


### PR DESCRIPTION
Notes:
- Bumped Version
- added abs.yaml to go to correct channel
- Made a slight change in run_tests.py to make be more lenient 
   - It seems with OpenSSL3 the name of the version outputs more than it does with OpenSSL 1.1.1