### PR TITLE
Update 41.0.1 PKG-2252

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,0 @@
-channels:
-  staging_openssl3: openssl3
-
-aggregate_branch: openssl3_builds
-
-build_parameters:
-  - "--suppress-variables"
-  #- "--skip-existing"
-  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,8 @@
 channels:
   staging_openssl3: openssl3
+
+aggregate_branch: openssl3_builds
+
 build_parameters:
   - "--suppress-variables"
   #- "--skip-existing"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  staging_openssl3: openssl3
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+# rust compilier specified so the rust-gnu compiler will not be used.
+rust_compiler:
+  - rust

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-rust_compiler:
-  - rust
-rust_compiler_version:
-  - 1.46.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,11 +23,10 @@ requirements:
   build:
     - {{ compiler('rust') }}
     - vs2017_{{ target_platform }}    # [win]
-    - cffi >=1.12
   host:
     - python
     - pip
-    - setuptools >=40.6.0,!=60.9.0
+    - setuptools >=61.0.0
     - setuptools-rust >=0.11.4
     - wheel
     - openssl {{openssl}}
@@ -40,18 +39,16 @@ requirements:
 
 test:
   requires:
-    - cryptography-vectors {{ version }}
-    - hypothesis >=1.11.4,!=3.79.2
-    - iso8601
+    - cryptography-vectors == {{ version }}
     - pip
-    - pretend
     - pytest >=6.2.0
-    - pytest-subtests
-    - pytest-xdist
     - pytest-benchmark
-    - pytz
+    - pytest-cov
+    - pytest-xdist
+    - pretend
   source_files:
     - tests
+    - pyproject.toml
   commands:
     - pip check
     # run_test.py will check that the correct openssl version is linked

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,8 @@ requirements:
   run:
     - python
     - cffi >=1.12
-    - openssl >1.1.0,<3.1.0
-    - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
+    - openssl 3.*
+      - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - python
     - cffi >=1.12
-    - openssl >1.1.0, <3.1.0
+    - openssl >1.1.0,<3.1.0
     - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,11 @@ requirements:
     - setuptools >=61.0.0
     - setuptools-rust >=0.11.4
     - wheel
-    - openssl {{openssl}}
+    - openssl {{openssl}} # [not ppc64le]
+    # linux-ppc64le failing test phase on all 1.1.1 builds skipping until 1.1.1 is dropped completely
+    # for more info on error: https://anaconda.atlassian.net/browse/PKG-2252
+    # This can be dropped after OpenSSL 1.1.1 support is dropped in Sept 2023
+    - openssl 3.0 # [ppc64le]
     - cffi >=1.12
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ requirements:
     - setuptools >=40.6.0,!=60.9.0
     - setuptools-rust >=0.11.4
     - wheel
-    - pkgconfig
     - openssl {{openssl}}
     - cffi >=1.12
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,9 @@ source:
   sha256: d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37 or win32]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 requirements:
@@ -28,7 +28,7 @@ requirements:
   run:
     - python
     - cffi >=1.12
-    - openssl
+    - openssl >1.1.0, <3.1.0
     - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "39.0.1" %}
+{% set version = "41.0.1" %}
 
 package:
   name: cryptography
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695
+  sha256: d34579085401d3f49762d2f7d6634d6b6c2ae1242202e860f4d26b046e3a1006
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<37 or win32]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:  # [s390x]
@@ -25,10 +25,11 @@ requirements:
     - setuptools >=40.6.0,!=60.9.0
     - setuptools-rust >=0.11.4
     - wheel
+    - openssl {{openssl}}
   run:
     - python
     - cffi >=1.12
-    - openssl 3.*
+    - openssl
     - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - setuptools >=40.6.0,!=60.9.0
     - setuptools-rust >=0.11.4
     - wheel
+    - pkgconfig
     - openssl {{openssl}}
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools >=40.6.0,!=60.9.0
     - setuptools-rust >=0.11.4
     - wheel
-    - openssl {{openssl}}
+#    - openssl {{openssl}}
   run:
     - python
     - cffi >=1.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,12 @@ source:
 build:
   number: 0
   skip: true  # [py<37 or win32]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script:
+  # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
+  # here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual
+  - export OPENSSL_DIR=$PREFIX        # [unix]
+  - set OPENSSL_DIR=%LIBRARY_PREFIX%  # [win]
+  - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     # linux-ppc64le failing test phase on all 1.1.1 builds skipping until 1.1.1 is dropped completely
     # for more info on error: https://anaconda.atlassian.net/browse/PKG-2252
     # This can be dropped after OpenSSL 1.1.1 support is dropped in Sept 2023
-    - openssl 3.0 # [ppc64le]
+    - openssl ==3.0.x # [ppc64le]
     - cffi >=1.12
   run:
     - python
@@ -43,7 +43,7 @@ requirements:
 
 test:
   requires:
-    - cryptography-vectors == {{ version }}
+    - cryptography-vectors {{ version }}
     - pip
     - pytest >=6.2.0
     - pytest-benchmark

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,15 +18,16 @@ requirements:
   build:
     - {{ compiler('rust') }}
     - vs2017_{{ target_platform }}    # [win]
+    - cffi >=1.12
   host:
     - python
-    - cffi >=1.12
     - pip
     - setuptools >=40.6.0,!=60.9.0
     - setuptools-rust >=0.11.4
     - wheel
     - pkgconfig
     - openssl {{openssl}}
+    - cffi >=1.12
   run:
     - python
     - cffi >=1.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - python
     - cffi >=1.12
     - openssl 3.*
-      - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
+    - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     # linux-ppc64le failing test phase on all 1.1.1 builds skipping until 1.1.1 is dropped completely
     # for more info on error: https://anaconda.atlassian.net/browse/PKG-2252
     # This can be dropped after OpenSSL 1.1.1 support is dropped in Sept 2023
-    - openssl ==3.0.x # [ppc64le]
+    - openssl ==3.0.* # [ppc64le]
     - cffi >=1.12
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools >=40.6.0,!=60.9.0
     - setuptools-rust >=0.11.4
     - wheel
-#    - openssl {{openssl}}
+    - openssl {{openssl}}
   run:
     - python
     - cffi >=1.12

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -20,8 +20,8 @@ linked_version = backend.openssl_version_text()
 # the version present in the conda environment
 env_version = subprocess.check_output('openssl version', shell=True).decode('utf8').strip()
 
-print('Version used by cryptography:\n{linked_version}'.format(linked_version=linked_version))
-print('Version in conda environment:\n{env_version}'.format(env_version=env_version))
+print(f'Version used by cryptography:\n{linked_version}')
+print(f'Version in conda environment:\n{env_version}')
 
 # avoid race condition between print and (possible) AssertionError
 time.sleep(1)
@@ -29,4 +29,5 @@ time.sleep(1)
 # linking problems have appeared on windows before (see issue #38),
 # and were only caught by lucky accident through the test suite.
 # This is intended to ensure it does not happen again.
-assert linked_version == env_version
+
+assert env_version.startswith(linked_version)


### PR DESCRIPTION
Merging in history from the OpenSSL 3 migration for historical purposes.
Also:
- Removing abs.yaml used for OpenSSL 3 update
- Updated version and sha hash
- Reset build number
- Removed pinned version of rust-compiler
- Adding OPENSSL environment variables to support new builds for versions > 40.
- Adding pyproject.toml to test source files to support testing