### PR TITLE
Updating version and hash.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "41.0.1" %}
+{% set version = "41.0.2" %}
 
 package:
   name: cryptography
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: d34579085401d3f49762d2f7d6634d6b6c2ae1242202e860f4d26b046e3a1006
+  sha256: 7d230bf856164de164ecb615ccc14c7fc6de6906ddd5b491f3af90d3514c925c
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,12 @@ source:
 build:
   number: 0
   skip: true  # [py<37 or win32]
+  # linux-ppc64le failing test phase on all 1.1.1 builds skipping until 1.1.1 is dropped completely
+  # for more info on error: https://anaconda.atlassian.net/browse/PKG-2252
+  # This can be dropped after OpenSSL 1.1.1 support is dropped in Sept 2023
+  {% if ARCH == "ppc64le" and (openssl | string).startswith('1.1.1') %}
+  skip: true
+  {% endif %}
   script:
   # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
   # here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual
@@ -23,18 +29,15 @@ requirements:
   build:
     - {{ compiler('rust') }}
     - vs2017_{{ target_platform }}    # [win]
+
   host:
     - python
     - pip
     - setuptools >=61.0.0
     - setuptools-rust >=0.11.4
     - wheel
-    - openssl {{openssl}} # [not ppc64le]
-    # linux-ppc64le failing test phase on all 1.1.1 builds skipping until 1.1.1 is dropped completely
-    # for more info on error: https://anaconda.atlassian.net/browse/PKG-2252
-    # This can be dropped after OpenSSL 1.1.1 support is dropped in Sept 2023
-    - openssl ==3.0.* # [ppc64le]
-    - cffi >=1.12
+    - openssl {{openssl}}
+    - cffi 1.15.1
   run:
     - python
     - cffi >=1.12


### PR DESCRIPTION
Updated version and hash.

No necessary requirement bumps:

https://github.com/pyca/cryptography/compare/41.0.1...41.0.2