### PR TITLE
Version 41.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "41.0.2" %}
+{% set version = "41.0.3" %}
 
 package:
   name: cryptography
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: 7d230bf856164de164ecb615ccc14c7fc6de6906ddd5b491f3af90d3514c925c
+  sha256: 6d192741113ef5e30d89dcb5b956ef4e1578f304708701b8b73d38e3e1461f34
 
 build:
   number: 0


### PR DESCRIPTION
[Upstream](https://github.com/pyca/cryptography/tree/41.0.3)
[Changelog](https://github.com/pyca/cryptography/blob/41.0.3/CHANGELOG.rst)

Basic patch level bump