### PR TITLE
Version 41.0.7

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: cryptography_41.0.7

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,1 @@
 aggregate_branch: 3.12
-
-channels:
-  - https://staging.continuum.io/prefect/fs/cryptography-vectors-feedstock/pr18/aa81d24

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
+aggregate_branch: 3.12
+
 channels:
   - https://staging.continuum.io/prefect/fs/cryptography-vectors-feedstock/pr18/4f8af94

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,1 @@
-build_parameters:
-  - "--suppress-variables"
-  - "--skip-existing"
-  - "--error-overlinking"
-
-staging_channel_upload_target: cryptography_41.0.7
+staging_channel_upload_target: crypt_41.0.7

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-staging_channel_upload_target: crypt_41.0.7
+channels:
+  - https://staging.continuum.io/prefect/fs/cryptography-vectors-feedstock/pr18/4f8af94

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 aggregate_branch: 3.12
 
 channels:
-  - https://staging.continuum.io/prefect/fs/cryptography-vectors-feedstock/pr18/4f8af94
+  - https://staging.continuum.io/prefect/fs/cryptography-vectors-feedstock/pr18/aa81d24

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,6 @@ source:
 build:
   number: 0
   skip: true  # [py<37 or win32]
-  # linux-ppc64le failing test phase on all 1.1.1 builds skipping until 1.1.1 is dropped completely
-  # for more info on error: https://anaconda.atlassian.net/browse/PKG-2252
-  # This can be dropped after OpenSSL 1.1.1 support is dropped in Sept 2023
-  {% if ARCH == "ppc64le" and (openssl | string).startswith('1.1.1') %}
-  skip: true
-  {% endif %}
   script:
   # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
   # here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "41.0.3" %}
+{% set version = "41.0.7" %}
 
 package:
   name: cryptography
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: 6d192741113ef5e30d89dcb5b956ef4e1578f304708701b8b73d38e3e1461f34
+  sha256: 13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc
 
 build:
   number: 0


### PR DESCRIPTION
[Jira Ticket
](https://anaconda.atlassian.net/browse/PKG-3547)[Upstream](https://github.com/pyca/cryptography/tree/41.0.7)
[Changelog
](https://github.com/pyca/cryptography/blob/41.0.7/CHANGELOG.rst)

## Actions
- Bump version to 41.0.7
- Remove outdated `linux-ppc64le` build steps

## Notes
- `abs.yaml` file for `Python 3.12` will be removed after merging