### PR TITLE
Rebuild to include PPC

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,6 @@ source:
 build:
   number: 1
   skip: true  # [py<37 or win32]
-  # linux-ppc64le failing test phase on all 1.1.1 builds skipping until 1.1.1 is dropped completely
-  # for more info on error: https://anaconda.atlassian.net/browse/PKG-2252
-  # This can be dropped after OpenSSL 1.1.1 support is dropped in Sept 2023
-  {% if ARCH == "ppc64le" and (openssl | string).startswith('1.1.1') %}
-  skip: true
-  {% endif %}
   script:
   # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
   # here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,14 @@ source:
   sha256: 13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37 or win32]
+  # linux-ppc64le failing test phase on all 1.1.1 builds skipping until 1.1.1 is dropped completely
+  # for more info on error: https://anaconda.atlassian.net/browse/PKG-2252
+  # This can be dropped after OpenSSL 1.1.1 support is dropped in Sept 2023
+  {% if ARCH == "ppc64le" and (openssl | string).startswith('1.1.1') %}
+  skip: true
+  {% endif %}
   script:
   # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
   # here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual


### PR DESCRIPTION
[Jira Ticket
](https://anaconda.atlassian.net/browse/PKG-3547)[Upstream](https://github.com/pyca/cryptography/tree/41.0.7)
[Changelog
](https://github.com/pyca/cryptography/blob/41.0.7/CHANGELOG.rst)

This is a rebuild of 41.0.7 with support for `linux - ppc64le` added per customer request. See the thread in the Jira ticket for more info.