### PR TITLE
Update to 42.0.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/cryptography-42.0.0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/cryptography-42.0.0
+  - https://staging.continuum.io/prefect/fs/cryptography-vectors-feedstock/pr19/961a3d5
+  - https://staging.continuum.io/prefect/fs/setuptools-rust-feedstock

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
   - https://staging.continuum.io/prefect/fs/cryptography-vectors-feedstock/pr19/961a3d5
-  - https://staging.continuum.io/prefect/fs/setuptools-rust-feedstock
+  - https://staging.continuum.io/prefect/fs/setuptools-rust-feedstock/pr5/855001d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "41.0.7" %}
+{% set version = "42.0.0" %}
 
 package:
   name: cryptography
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: 13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc
+  sha256: 6cf9b76d6e93c62114bd19485e5cb003115c134cf9ce91f8ac924c44f8c8c3f4
 
 build:
   number: 0
@@ -58,9 +58,12 @@ test:
 
 about:
   home: https://github.com/pyca/cryptography
-  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
-  license_family: BSD
-  license_url: https://github.com/pyca/cryptography/blob/{{ version }}/vectors/LICENSE
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: Apache
+  license_file: |
+    - LICENSE
+    - LICENSE.APACHE
+    - LICENSE.BSD
   summary: Provides cryptographic recipes and primitives to Python developers
   description: |
     Cryptography is a package which provides cryptographic recipes and
@@ -69,7 +72,7 @@ about:
     cryptography includes both high level recipes and low level interfaces to
     common cryptographic algorithms such as symmetric ciphers, message digests,
     and key derivation functions.
-  doc_url: https://cryptography.io/en/{{ version }}/
+  doc_url: https://cryptography.io/
   dev_url: https://github.com/pyca/cryptography
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,8 +60,11 @@ test:
 about:
   home: https://github.com/pyca/cryptography
   license: Apache-2.0 OR BSD-3-Clause
-  license_family: Apache
-  license_file: LICENSE
+  license_family: OTHER
+  license_file:
+    - LICENSE
+    - LICENSE.APACHE
+    - LICENSE.BSD
   summary: Provides cryptographic recipes and primitives to Python developers
   description: |
     Cryptography is a package which provides cryptographic recipes and

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,10 +60,7 @@ about:
   home: https://github.com/pyca/cryptography
   license: Apache-2.0 OR BSD-3-Clause
   license_family: Apache
-  license_file:
-    - LICENSE
-    - LICENSE.APACHE
-    - LICENSE.BSD
+  license_file: LICENSE
   summary: Provides cryptographic recipes and primitives to Python developers
   description: |
     Cryptography is a package which provides cryptographic recipes and

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ requirements:
 
 test:
   requires:
+    - certifi
     - cryptography-vectors {{ version }}
     - pip
     - pytest >=6.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: 6cf9b76d6e93c62114bd19485e5cb003115c134cf9ce91f8ac924c44f8c8c3f4
+  sha256: e0ec52ba3c7f1b7d813cd52649a5b3ef1fc0d433219dc8c93827c57eab6cf888
 
 build:
   number: 0
@@ -28,7 +28,7 @@ requirements:
     - python
     - pip
     - setuptools >=61.0.0
-    - setuptools_rust >=1.7.0
+    - setuptools-rust >=1.7.0
     - wheel
     - openssl {{openssl}}
     - cffi 1.15.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "42.0.0" %}
+{% set version = "42.0.2" %}
 
 package:
   name: cryptography
@@ -28,7 +28,7 @@ requirements:
     - python
     - pip
     - setuptools >=61.0.0
-    - setuptools-rust >=1.7.0
+    - setuptools_rust >=1.7.0
     - wheel
     - openssl {{openssl}}
     - cffi 1.15.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37 or win32]
+  skip: true  # [py<37]
   script:
   # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
   # here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual
@@ -28,7 +28,7 @@ requirements:
     - python
     - pip
     - setuptools >=61.0.0
-    - setuptools-rust >=0.11.4
+    - setuptools-rust >=1.7.0
     - wheel
     - openssl {{openssl}}
     - cffi 1.15.1
@@ -60,7 +60,7 @@ about:
   home: https://github.com/pyca/cryptography
   license: Apache-2.0 OR BSD-3-Clause
   license_family: Apache
-  license_file: |
+  license_file:
     - LICENSE
     - LICENSE.APACHE
     - LICENSE.BSD
@@ -72,8 +72,8 @@ about:
     cryptography includes both high level recipes and low level interfaces to
     common cryptographic algorithms such as symmetric ciphers, message digests,
     and key derivation functions.
-  doc_url: https://cryptography.io/
   dev_url: https://github.com/pyca/cryptography
+  doc_url: https://cryptography.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
### cryptography 42.0.2

**Destination channel:** {defaults}

### Links

- [PKG-4018](https://anaconda.atlassian.net/browse/PKG-4018) 
- [Upstream repository](https://github.com/pyca/cryptography/tree/42.0.2)
- [Upstream changelog/diff](https://cryptography.io/en/latest/changelog/)
- Relevant dependency PRs:
  - [cryptography-vectors](https://github.com/AnacondaRecipes/cryptography-vectors-feedstock/pull/19)
  - [setuptools-rust](https://github.com/AnacondaRecipes/setuptools-rust-feedstock/pull/5)

### Explanation of changes:

- Updated `version` and `sha256`
- Changed `license_url` to `license_file`
- Updated `setuptools-rust` dependency
- Updated url to not redirect to `en` for non-English readers
- Added `certifi` to satisfy failing test

[PKG-4018]: https://anaconda.atlassian.net/browse/PKG-4018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ