### PR TITLE
42.0.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/setuptools-rust-feedstock/pr6/7216911

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/setuptools-rust-feedstock/pr6/7216911

--- a/recipe/bldsplit.bat
+++ b/recipe/bldsplit.bat
@@ -1,0 +1,14 @@
+echo on
+
+if [%PKG_NAME%] == [cryptography-vectors] (
+  %PYTHON% -m pip install .\cryptography-vectors -vv --no-deps --no-build-isolation
+  if errorlevel 1 exit 1
+)
+
+if [%PKG_NAME%] == [cryptography] (
+  REM As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
+  REM here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual
+  set OPENSSL_DIR=%LIBRARY_PREFIX%
+  %PYTHON% -m pip install .\cryptography -vv --no-deps --no-build-isolation
+  if errorlevel 1 exit 1
+)

--- a/recipe/bldsplit.bat
+++ b/recipe/bldsplit.bat
@@ -9,6 +9,10 @@ if [%PKG_NAME%] == [cryptography] (
   REM As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
   REM here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual
   set OPENSSL_DIR=%LIBRARY_PREFIX%
-  %PYTHON% -m pip install .\cryptography -vv --no-deps --no-build-isolation
+  REM setuptools-rust 1.9.0 has py-limited-api set to auto by default
+  REM this seem to not play well with our build, resulting with the py38 package rust binding to use python API introcuded in python 3.9
+  REM https://setuptools-rust.readthedocs.io/en/v1.9.0/building_wheels.html#building-for-abi3
+  set PY_VER_ND=%PY_VER:.=%
+  %PYTHON% -m pip install .\cryptography -vv --no-deps --no-build-isolation --global-option=--build-option=--py-limited-api=cp%PY_VER_ND%
   if errorlevel 1 exit 1
 )

--- a/recipe/bldsplit.sh
+++ b/recipe/bldsplit.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+echo "Building ${PKG_NAME}."
+
+if [[ "${PKG_NAME}" == "cryptography-vectors" ]]; then
+    $PYTHON -m pip install ./cryptography-vectors -vv --no-deps --no-build-isolation
+elif [[ "${PKG_NAME}" == "cryptography" ]]; then
+    # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
+    # here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual
+    export OPENSSL_DIR=$PREFIX
+    $PYTHON -m pip install ./cryptography -vv --no-deps --no-build-isolation
+fi

--- a/recipe/bldsplit.sh
+++ b/recipe/bldsplit.sh
@@ -10,5 +10,8 @@ elif [[ "${PKG_NAME}" == "cryptography" ]]; then
     # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
     # here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual
     export OPENSSL_DIR=$PREFIX
-    $PYTHON -m pip install ./cryptography -vv --no-deps --no-build-isolation
+    # setuptools-rust 1.9.0 has py-limited-api set to auto by default
+    # this seem to not play well with our build, resulting with the py38 package rust binding to use python API introcuded in python 3.9
+    # https://setuptools-rust.readthedocs.io/en/v1.9.0/building_wheels.html#building-for-abi3
+    $PYTHON -m pip install ./cryptography -vv --no-deps --no-build-isolation --global-option=--build-option=--py-limited-api=cp${PY_VER//./}
 fi

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,0 @@
-# rust compilier specified so the rust-gnu compiler will not be used.
-rust_compiler:
-  - rust

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,80 +1,114 @@
-{% set version = "42.0.2" %}
+{% set version = "42.0.5" %}
 
 package:
-  name: cryptography
+  name: cryptography-split
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: e0ec52ba3c7f1b7d813cd52649a5b3ef1fc0d433219dc8c93827c57eab6cf888
+  - url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
+    sha256: 6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1
+    folder: cryptography
+  - url: https://pypi.io/packages/source/c/cryptography_vectors/cryptography_vectors-{{ version }}.tar.gz
+    sha256: 505cd5e3b0cb32da1526f07042b7fc38a4b6c356710cb73d2b5f76b037a38ed1
+    folder: cryptography-vectors
 
 build:
   number: 0
-  skip: true  # [py<37]
-  script:
-  # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
-  # here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual
-  - export OPENSSL_DIR=$PREFIX        # [unix]
-  - set OPENSSL_DIR=%LIBRARY_PREFIX%  # [win]
-  - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  missing_dso_whitelist:  # [s390x]
-    - $RPATH/ld64.so.1    # [s390x]
-requirements:
-  build:
-    - {{ compiler('rust') }}
-    - vs2017_{{ target_platform }}    # [win]
+  skip: true  # [py<38]
 
-  host:
-    - python
-    - pip
-    - setuptools >=61.0.0
-    - setuptools-rust >=1.7.0
-    - wheel
-    - openssl {{openssl}}
-    - cffi 1.15.1
-  run:
-    - python
-    - cffi >=1.12
-    - openssl
-    - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
+outputs:
+  - name: cryptography-vectors
+    # releases of cryptrography and cryptography-vectors are released in sync
+    script: bldsplit.sh # [unix]
+    script: bldsplit.bat # [win]
+    requirements:
+      host:
+        - python
+        - pip
+        - flit-core
+      run:
+        - python
+    test:
+      requires:
+        - pip
+      commands:
+        - pip check
+      imports:
+        - cryptography_vectors
+    about:
+      home: https://github.com/pyca/cryptography
+      license: Apache-2.0 OR BSD-3-Clause
+      license_family: OTHER
+      license_file:
+        - cryptography-vectors/LICENSE
+        - cryptography-vectors/LICENSE.APACHE
+        - cryptography-vectors/LICENSE.BSD
+      summary: Test vectors for cryptography.
+      description: |
+        This package contains test vectors for the cryptography package.
+      dev_url: https://github.com/pyca/cryptography/tree/main/vectors
+      doc_url: https://cryptography.io/
 
-test:
-  requires:
-    - certifi
-    - cryptography-vectors {{ version }}
-    - pip
-    - pytest >=6.2.0
-    - pytest-benchmark
-    - pytest-cov
-    - pytest-xdist
-    - pretend
-  source_files:
-    - tests
-    - pyproject.toml
-  commands:
-    - pip check
-    # run_test.py will check that the correct openssl version is linked
-    - pytest -n auto #  [not arm64]
-    - pytest -n auto -k "not (test_der_x509_certificate_extensions[x509/PKITS_data/certs/ValidcRLIssuerTest28EE.crt] or test_x509_csr_extensions or test_no_leak_free or test_no_leak_no_malloc or test_leak or test_load_pkcs12_key_and_certificates[pkcs12/cert-key-aes256cbc.p12] or test_create_certificate_with_extensions or test_ec_derive_private_key or test_ec_private_numbers_private_key or test_create_ocsp_request or test_write_pkcs12_key_and_certificates or test_errors or test_load_pkcs12_key_and_certificates[pkcs12/cert-aes256cbc-no-key.p12] or test_ec_private_numbers_private_key or test_pem_x509_certificate_extensions[x509/cryptography.io.pem] or test_create_crl_with_idp or test_no_leak_gc or test_x25519_pubkey_from_private_key)" # [arm64]
-
-about:
-  home: https://github.com/pyca/cryptography
-  license: Apache-2.0 OR BSD-3-Clause
-  license_family: OTHER
-  license_file:
-    - LICENSE
-    - LICENSE.APACHE
-    - LICENSE.BSD
-  summary: Provides cryptographic recipes and primitives to Python developers
-  description: |
-    Cryptography is a package which provides cryptographic recipes and
-    primitives to Python developers. Our goal is for it to be your
-    "cryptographic standard library". It supports Python 3.6+ and PyPy3 7.2+.
-    cryptography includes both high level recipes and low level interfaces to
-    common cryptographic algorithms such as symmetric ciphers, message digests,
-    and key derivation functions.
-  dev_url: https://github.com/pyca/cryptography
-  doc_url: https://cryptography.io/
+  - name: cryptography
+    script: bldsplit.sh # [unix]
+    script: bldsplit.bat # [win]
+    build:
+      missing_dso_whitelist:  # [s390x]
+        - $RPATH/ld64.so.1    # [s390x]
+    requirements:
+      build:
+        - {{ compiler('rust') }}
+        - vs2017_{{ target_platform }}    # [win]
+      host:
+        - python
+        - pip
+        - setuptools >=61.0.0
+        - setuptools-rust >=1.7.0
+        - wheel
+        - openssl {{openssl}}
+        - cffi 1.15.1
+      run:
+        - python
+        - cffi >=1.12
+        - openssl
+        - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
+    test:
+      requires:
+        - certifi
+        - cryptography-vectors {{ version }}
+        - pip
+        - pytest >=6.2.0
+        - pytest-benchmark
+        - pytest-cov
+        - pytest-xdist
+        - pretend
+      source_files:
+        - cryptography/tests
+        - cryptography/pyproject.toml
+      commands:
+        - pip check
+        # run_test.py will check that the correct openssl version is linked
+        - pytest -n auto
+        #- pytest -n auto #  [not arm64]
+        #- pytest -n auto -k "not (test_der_x509_certificate_extensions[x509/PKITS_data/certs/ValidcRLIssuerTest28EE.crt] or test_x509_csr_extensions or test_no_leak_free or test_no_leak_no_malloc or test_leak or test_load_pkcs12_key_and_certificates[pkcs12/cert-key-aes256cbc.p12] or test_create_certificate_with_extensions or test_ec_derive_private_key or test_ec_private_numbers_private_key or test_create_ocsp_request or test_write_pkcs12_key_and_certificates or test_errors or test_load_pkcs12_key_and_certificates[pkcs12/cert-aes256cbc-no-key.p12] or test_ec_private_numbers_private_key or test_pem_x509_certificate_extensions[x509/cryptography.io.pem] or test_create_crl_with_idp or test_no_leak_gc or test_x25519_pubkey_from_private_key)" # [arm64]
+    about:
+      home: https://github.com/pyca/cryptography
+      license: Apache-2.0 OR BSD-3-Clause
+      license_family: OTHER
+      license_file:
+        - cryptography/LICENSE
+        - cryptography/LICENSE.APACHE
+        - cryptography/LICENSE.BSD
+      summary: Provides cryptographic recipes and primitives to Python developers
+      description: |
+        cryptography is a package which provides cryptographic recipes and
+        primitives to Python developers. Our goal is for it to be your
+        "cryptographic standard library".
+        cryptography includes both high level recipes and low level interfaces to
+        common cryptographic algorithms such as symmetric ciphers, message digests,
+        and key derivation functions.
+      dev_url: https://github.com/pyca/cryptography
+      doc_url: https://cryptography.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,6 +88,7 @@ outputs:
       commands:
         - pip check
         # run_test.py will check that the correct openssl version is linked
+        - cd cryptography
         - pytest -n auto
     about:
       home: https://github.com/pyca/cryptography

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,8 +89,6 @@ outputs:
         - pip check
         # run_test.py will check that the correct openssl version is linked
         - pytest -n auto
-        #- pytest -n auto #  [not arm64]
-        #- pytest -n auto -k "not (test_der_x509_certificate_extensions[x509/PKITS_data/certs/ValidcRLIssuerTest28EE.crt] or test_x509_csr_extensions or test_no_leak_free or test_no_leak_no_malloc or test_leak or test_load_pkcs12_key_and_certificates[pkcs12/cert-key-aes256cbc.p12] or test_create_certificate_with_extensions or test_ec_derive_private_key or test_ec_private_numbers_private_key or test_create_ocsp_request or test_write_pkcs12_key_and_certificates or test_errors or test_load_pkcs12_key_and_certificates[pkcs12/cert-aes256cbc-no-key.p12] or test_ec_private_numbers_private_key or test_pem_x509_certificate_extensions[x509/cryptography.io.pem] or test_create_crl_with_idp or test_no_leak_gc or test_x25519_pubkey_from_private_key)" # [arm64]
     about:
       home: https://github.com/pyca/cryptography
       license: Apache-2.0 OR BSD-3-Clause


### PR DESCRIPTION
Changes:
- update from 42.0.5
- include cryptography-vector as a second output, given cryptography and cryptography-vectors are always released in sync.

https://github.com/pyca/cryptography/tree/42.0.5
https://github.com/pyca/cryptography/tree/42.0.5/vectors

Edit: for some unknown reason, the test fail for py38 with the rust binding calling python functions introduced in 3.9. Reverting to separate cryptography/cryptography-vectors for now due to time constraint.