### PR TITLE
Updated to 43.0.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
-# rust compilier specified so the rust-gnu compiler will not be used.
+# rust compiler specified so the rust-gnu compiler will not be used.
 rust_compiler:
   - rust
 rust_compiler_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "42.0.5" %}
+{% set version = "43.0.0" %}
 
 package:
   name: cryptography
@@ -6,39 +6,42 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: 6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1
+  sha256: b88075ada2d51aa9f18283532c9f60e72170041bba88d7f37e49cbb10275299e
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<37]
   script:
-  # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
-  # here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual
-  - export OPENSSL_DIR=$PREFIX        # [unix]
-  - set OPENSSL_DIR=%LIBRARY_PREFIX%  # [win]
-  - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
+    # here is the documentation on setting things manually, https://docs.rs/openssl/latest/openssl/#manual
+    - export OPENSSL_DIR=$PREFIX        # [unix]
+    - set OPENSSL_DIR=%LIBRARY_PREFIX%  # [win]
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 requirements:
   build:
     - {{ compiler('rust') }}
-    # forcing rust to 1.71 to keep compatiblity with osx 10.9.
+    # forcing rust to 1.71 to keep compatibility with osx 10.9.
     - rust <1.72
     - vs2017_{{ target_platform }}    # [win]
   host:
     - python
     - pip
-    - setuptools >=61.0.0
-    - setuptools-rust >=1.7.0
+    - setuptools !=74.0.0
     - wheel
+    - maturin >=1,<2
     - openssl {{openssl}}
-    - cffi 1.15.1
+    - cffi >=1.12
   run:
     - python
     - cffi >=1.12
     - openssl
     - libgcc-ng     # [linux]; needed by `_rust.abi3.so`
+  run_constrained:
+    - bcrypt >=3.1.5
 
+# Import tests take place in run_test.py
 test:
   requires:
     - certifi
@@ -56,7 +59,7 @@ test:
     - pip check
     # run_test.py will check that the correct openssl version is linked
     - pytest -n auto #  [not arm64]
-    - pytest -n auto -k "not (test_der_x509_certificate_extensions[x509/PKITS_data/certs/ValidcRLIssuerTest28EE.crt] or test_x509_csr_extensions or test_no_leak_free or test_no_leak_no_malloc or test_leak or test_load_pkcs12_key_and_certificates[pkcs12/cert-key-aes256cbc.p12] or test_create_certificate_with_extensions or test_ec_derive_private_key or test_ec_private_numbers_private_key or test_create_ocsp_request or test_write_pkcs12_key_and_certificates or test_errors or test_load_pkcs12_key_and_certificates[pkcs12/cert-aes256cbc-no-key.p12] or test_ec_private_numbers_private_key or test_pem_x509_certificate_extensions[x509/cryptography.io.pem] or test_create_crl_with_idp or test_no_leak_gc or test_x25519_pubkey_from_private_key)" # [arm64]
+    - pytest -n auto -k "not (test_x509_csr_extensions or test_no_leak_free or test_no_leak_no_malloc or test_leak or test_create_certificate_with_extensions or test_ec_derive_private_key or test_ec_private_numbers_private_key or test_create_ocsp_request or test_write_pkcs12_key_and_certificates or test_errors or test_ec_private_numbers_private_key or test_create_crl_with_idp or test_no_leak_gc or test_x25519_pubkey_from_private_key)" # [arm64]
 
 about:
   home: https://github.com/pyca/cryptography

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -7,10 +7,13 @@ import cryptography.hazmat.backends
 import cryptography.hazmat.backends.openssl
 import cryptography.hazmat.bindings
 import cryptography.hazmat.bindings.openssl
+import cryptography.hazmat.decrepit
+import cryptography.hazmat.decrepit.ciphers
 import cryptography.hazmat.primitives
 import cryptography.hazmat.primitives.asymmetric
 import cryptography.hazmat.primitives.ciphers
 import cryptography.hazmat.primitives.kdf
+import cryptography.hazmat.primitives.serialization
 import cryptography.hazmat.primitives.twofactor
 import cryptography.x509
 from cryptography.hazmat.backends.openssl import backend


### PR DESCRIPTION
cryptography 43.0.0

**Destination channel:** defaults

### Links

- [PKG-5320](https://anaconda.atlassian.net/browse/PKG-5320) 
- [Upstream repository](https://github.com/pyca/cryptography)
- [Upstream changelog/diff](https://github.com/pyca/cryptography/blob/43.0.0/CHANGELOG.rst)
- Relevant dependency PRs:
  - AnacondaRecipes/cryptography-vectors-feedstock#21

### Explanation of changes:

- Updated tests to include more imports
- Removed some special test omissions on osx-arm as they are now handled internally
- Updated build system to maturin to match upstream

[PKG-5320]: https://anaconda.atlassian.net/browse/PKG-5320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ