### PR TITLE
cryptography 43.0.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/cryptography-vectors-feedstock/pr22/f4955f2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/cryptography-vectors-feedstock/pr22/f4955f2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ test:
     - pip
     - pytest >=6.2.0
     - pytest-xdist
+    - pytest-benchmark
     - pretend
   source_files:
     - tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,11 +28,11 @@ requirements:
   host:
     - python
     - pip
-    - setuptools !=74.0.0
+    - setuptools !=74.0.0,!=74.1.0,!=74.1.1,!=74.1.2,!=74.1.3,!=75.0.0,!=75.1.0,!=75.2.0
     - wheel
     - maturin >=1,<2
-    - openssl {{openssl}}
     - cffi >=1.12
+    - openssl {{ openssl }}
   run:
     - python
     - cffi >=1.12
@@ -49,7 +49,6 @@ test:
     - pip
     - pytest >=6.2.0
     - pytest-benchmark
-    - pytest-cov
     - pytest-xdist
     - pretend
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,6 @@ test:
     - cryptography-vectors {{ version }}
     - pip
     - pytest >=6.2.0
-    - pytest-benchmark
     - pytest-xdist
     - pretend
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,8 +56,8 @@ test:
   commands:
     - pip check
     # run_test.py will check that the correct openssl version is linked
-    - pytest -n auto #  [not arm64]
-    - pytest -n auto -k "not (test_x509_csr_extensions or test_no_leak_free or test_no_leak_no_malloc or test_leak or test_create_certificate_with_extensions or test_ec_derive_private_key or test_ec_private_numbers_private_key or test_create_ocsp_request or test_write_pkcs12_key_and_certificates or test_errors or test_ec_private_numbers_private_key or test_create_crl_with_idp or test_no_leak_gc or test_x25519_pubkey_from_private_key)" # [arm64]
+    - pytest tests #  [not arm64]
+    - pytest -k "not (test_x509_csr_extensions or test_no_leak_free or test_no_leak_no_malloc or test_leak or test_create_certificate_with_extensions or test_ec_derive_private_key or test_ec_private_numbers_private_key or test_create_ocsp_request or test_write_pkcs12_key_and_certificates or test_errors or test_ec_private_numbers_private_key or test_create_crl_with_idp or test_no_leak_gc or test_x25519_pubkey_from_private_key) tests" # [arm64]
 
 about:
   home: https://github.com/pyca/cryptography

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "43.0.0" %}
+{% set version = "43.0.3" %}
 
 package:
   name: cryptography

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ test:
     - pip check
     # run_test.py will check that the correct openssl version is linked
     - pytest tests #  [not arm64]
-    - pytest -k "not (test_x509_csr_extensions or test_no_leak_free or test_no_leak_no_malloc or test_leak or test_create_certificate_with_extensions or test_ec_derive_private_key or test_ec_private_numbers_private_key or test_create_ocsp_request or test_write_pkcs12_key_and_certificates or test_errors or test_ec_private_numbers_private_key or test_create_crl_with_idp or test_no_leak_gc or test_x25519_pubkey_from_private_key) tests" # [arm64]
+    - pytest -k "not (test_x509_csr_extensions or test_no_leak_free or test_no_leak_no_malloc or test_leak or test_create_certificate_with_extensions or test_ec_derive_private_key or test_ec_private_numbers_private_key or test_create_ocsp_request or test_write_pkcs12_key_and_certificates or test_errors or test_ec_private_numbers_private_key or test_create_crl_with_idp or test_no_leak_gc or test_x25519_pubkey_from_private_key)" tests # [arm64]
 
 about:
   home: https://github.com/pyca/cryptography

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: b88075ada2d51aa9f18283532c9f60e72170041bba88d7f37e49cbb10275299e
+  sha256: 315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805
 
 build:
   number: 0


### PR DESCRIPTION
cryptography 43.0.1 

**Destination channel:** Defaults

### Links

- [PKG-5800]
- dev_url:        https://github.com/pyca/cryptography/tree/43.0.3
- conda_forge:    https://github.com/conda-forge/cryptography-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/cryptography/43.0.3
- pypi inspector: https://inspector.pypi.io/project/cryptography/43.0.3

### Explanation of changes:

- new version number


[PKG-5800]: https://anaconda.atlassian.net/browse/PKG-5800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ