### PR TITLE
V43.0.0b1 rust rebuild

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,3 @@
 # rust compiler specified so the rust-gnu compiler will not be used.
 rust_compiler:
   - rust
-rust_compiler_version:
-  - 1.71.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b88075ada2d51aa9f18283532c9f60e72170041bba88d7f37e49cbb10275299e
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   script:
     # As of cryptography version 40.0.0, build instructions have changed: https://cryptography.io/en/latest/changelog/#v40-0-0
@@ -22,8 +22,6 @@ build:
 requirements:
   build:
     - {{ compiler('rust') }}
-    # forcing rust to 1.71 to keep compatibility with osx 10.9.
-    - rust <1.72
     - vs2017_{{ target_platform }}    # [win]
   host:
     - python


### PR DESCRIPTION
cryptography v43.0.0 rebuild

**Destination channel:** defaults

### Links

- [PKG-6200](https://anaconda.atlassian.net/browse/PKG-6200)
 
### Explanation of changes:
  - Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.


[PKG-6200]: https://anaconda.atlassian.net/browse/PKG-6200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ