### PR TITLE
cryptography 45.0.5 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/cryptography-vectors-feedstock/pr25/2cfc036

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "45.0.3" %}
+{% set version = "45.0.5" %}
 
 package:
   name: cryptography
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography/cryptography-{{ version }}.tar.gz
-  sha256: ec21313dd335c51d7877baf2972569f40a4291b76a0ce51391523ae358d05899
+  sha256: 72e76caa004ab63accdf26023fccd1d087f6d90ec6048ff33ad0445abf7f605a
 
 build:
   number: 0
@@ -17,8 +17,6 @@ build:
     - export OPENSSL_DIR=$PREFIX        # [unix]
     - set OPENSSL_DIR=%LIBRARY_PREFIX%  # [win]
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  missing_dso_whitelist:  # [s390x]
-    - $RPATH/ld64.so.1    # [s390x]
 requirements:
   build:
     - {{ compiler('rust') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - setuptools !=74.0.0,!=74.1.0,!=74.1.1,!=74.1.2
     - wheel
     - maturin >=1.8.6,<2
-    - cffi >=1.14
+    - cffi 1.17.1
     - openssl {{ openssl }}
   run:
     - python


### PR DESCRIPTION
cryptography 45.0.5 

**Destination channel:** Defaults

### Links

- [PKG-8872]
- dev_url:        https://github.com/pyca/cryptography/tree/45.0.5
- conda_forge:    https://github.com/conda-forge/cryptography-feedstock
- pypi:           https://pypi.org/project/cryptography/45.0.5
- pypi inspector: https://inspector.pypi.io/project/cryptography/45.0.5/

### Explanation of changes:

- new version number


[PKG-8872]: https://anaconda.atlassian.net/browse/PKG-8872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ