### PR TITLE
cryptography 46.0.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography" %}
-{% set version = "46.0.5" %}
+{% set version = "46.0.6" %}
 
 package:
   name: {{ name }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pyca/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 7571f0e09a6d6eb22168993f94d35867b4dcbd0d34224e0eb7b392b905b3f12f
+  sha256: 234935d92ba2320836036c281163ea64837455dd7e0aaa0f034e574ccc7b4c64
 
 requirements:
   host:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-13262](https://anaconda.atlassian.net/browse/PKG-13262)
- [Upstream repository](https://github.com/pyca/cryptography/tree/46.0.6)
- [Upstream changelog/diff](https://github.com/pyca/cryptography/tree/46.0.6)

### Explanation of changes:

- Bump version number
- Fixes https://www.cve.org/CVERecord?id=CVE-2026-34073 


[PKG-13262]: https://anaconda.atlassian.net/browse/PKG-13262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ