### PR TITLE
cryptography 50.0.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
 outputs:
   - name: {{ name }}-vectors
     script: build_vectors.bat  # [win]
-    script: build_vectors.sh  # [not win]
+    script: build_vectors.sh   # [not win]
     run_exports:
       - {{ pin_subpackage('cryptography-vectors', max_pin='x.x.x') }}
     requirements:
@@ -43,7 +43,7 @@ outputs:
 
   - name: {{ name }}
     script: build_main.bat  # [win]
-    script: build_main.sh  # [not win]
+    script: build_main.sh   # [not win]
     requirements:
       build:
         # Do not use stdlib('c') on Windows, as it clashes with the current rust 1.90.0.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ outputs:
         - pip
       commands:
         - pip check
+
   - name: {{ name }}
     script: build_main.bat  # [win]
     script: build_main.sh  # [not win]
@@ -59,15 +60,19 @@ outputs:
         - setuptools !=74.0.0,!=74.1.0,!=74.1.1,!=74.1.2
       run:
         - python
-        - cffi    >=2.0.0
+        - cffi >=2.0.0
         # cryptography/hazmat/bindings/_rust.abi3.so requires DSO lib/libssl.so.3
         - openssl
         - typing-extensions >=4.13.2  # [py<311]
       run_constrained:
+        # ssh
         - bcrypt >=3.1.5
         - python !=3.9.0,!=3.9.1
     # Import tests take place in run_test.py
     test:
+      source_files:
+        - tests
+        - pyproject.toml
       imports:
         - cryptography
         - cryptography.fernet
@@ -90,14 +95,11 @@ outputs:
         - pytest >=7.4.0
         - pytest-benchmark >=4.0
         - pytest-xdist >=3.5.0
-      source_files:
-        - tests
-        - pyproject.toml
       commands:
         - echo ON  # [win]
         - pip check
         # run_test.py will check that the correct openssl version is linked
-        - pytest -v tests
+        - pytest -vv tests
 
 about:
   home: https://github.com/pyca/cryptography

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ outputs:
       host:
         - pip
         - python
-        - uv-build >=0.7.19,<0.12.0
+        - uv-build >=0.7.19,<0.13.0
       run:
         - python
     test:
@@ -54,7 +54,7 @@ outputs:
         - python
         - pip
         - cffi >=2.0.0
-        - maturin >=1.9.4,<2,!=1.12.0
+        - maturin >=1.14.1,<2
         - openssl {{ openssl }}
         - wheel
         - setuptools !=74.0.0,!=74.1.0,!=74.1.1,!=74.1.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography" %}
-{% set version = "49.0.0" %}
+{% set version = "50.0.0" %}
 
 package:
   name: {{ name }}-split
@@ -7,7 +7,11 @@ package:
 
 source:
   url: https://github.com/pyca/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: a533606510cdea9e0f0616c61b18dbe3cfa5a2bbfbf48344a159d6ddc207ae13
+  sha256: 173ac75ea60351540a237b8d4fde5d89b5d6645545771dfe3c9abe8b637f2b35
+
+build:
+  number: 0
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -16,14 +20,10 @@ requirements:
   run:
     - python
 
-build:
-  number: 0
-  skip: true  # [py<39]
-
 outputs:
   - name: {{ name }}-vectors
     script: build_vectors.bat  # [win]
-    script: build_vectors.sh   # [not win]
+    script: build_vectors.sh  # [not win]
     run_exports:
       - {{ pin_subpackage('cryptography-vectors', max_pin='x.x.x') }}
     requirements:
@@ -42,7 +42,7 @@ outputs:
         - pip check
   - name: {{ name }}
     script: build_main.bat  # [win]
-    script: build_main.sh   # [not win]
+    script: build_main.sh  # [not win]
     requirements:
       build:
         # Do not use stdlib('c') on Windows, as it clashes with the current rust 1.90.0.
@@ -59,7 +59,7 @@ outputs:
         - setuptools !=74.0.0,!=74.1.0,!=74.1.1,!=74.1.2
       run:
         - python
-        - cffi>=2.0.0
+        - cffi    >=2.0.0
         # cryptography/hazmat/bindings/_rust.abi3.so requires DSO lib/libssl.so.3
         - openssl
         - typing-extensions >=4.13.2  # [py<311]
@@ -116,7 +116,7 @@ about:
     primitives to Python developers. Our goal is for it to be your
     "cryptographic standard library". It supports 3.8+ / PyPy 7.3.11+.
     cryptography includes both high level recipes and low level interfaces to
-    common cryptographic algorithms such as symmetric ciphers, 
+    common cryptographic algorithms such as symmetric ciphers,
     message digests, and key derivation functions.
   dev_url: https://github.com/pyca/cryptography
   doc_url: https://cryptography.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -128,3 +128,6 @@ extra:
     - jakirkham
     - ocefpaf
     - chenghlee
+  skip-lints:
+    - missing_imports_or_run_test_py
+    - should_use_stdlib


### PR DESCRIPTION
cryptography 50.0.0 

**Destination channel:** Defaults

### Links

- [PKG-16972]
- dev_url:        https://github.com/pyca/cryptography/tree/50.0.0
- conda_forge:    https://github.com/conda-forge/cryptography-feedstock
- pypi:           https://pypi.org/project/cryptography/50.0.0
- pypi inspector: https://inspector.pypi.io/project/cryptography/50.0.0

### Explanation of changes:

- new version number

### Tests:

- no rebuilds required, all 3 proposed packages (mlflow, oci, pyopenssl) has upperbound <50.0
- downstream tests is ongoing

[PKG-16972]: https://anaconda.atlassian.net/browse/PKG-16972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ